### PR TITLE
Add rainbowsniffer SvelteKit film rating app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+# Node / SvelteKit
+node_modules/
+.svelte-kit/
+build/
+.vite/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # pubcodex
+
+Ce dépôt contient l'application **rainbowsniffer**, un petit site de notation de films construit avec SvelteKit.
+
+Le code source de l'application se trouve dans le dossier [`rainbowsniffer`](rainbowsniffer).

--- a/rainbowsniffer/README.md
+++ b/rainbowsniffer/README.md
@@ -1,0 +1,16 @@
+# rainbowsniffer
+
+Un petit site de notation de films construit avec SvelteKit.
+
+## Développement
+
+```
+npm install
+npm run dev
+```
+
+## Tests
+
+```
+npm test
+```

--- a/rainbowsniffer/package.json
+++ b/rainbowsniffer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rainbowsniffer",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "svelte": "^4.2.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/rainbowsniffer/src/app.d.ts
+++ b/rainbowsniffer/src/app.d.ts
@@ -1,0 +1,10 @@
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+// and what to do when importing types
+// from packages.
+declare namespace App {
+  // interface Locals {}
+  // interface PageData {}
+  // interface PageState {}
+  // interface Platform {}
+}

--- a/rainbowsniffer/src/routes/+page.svelte
+++ b/rainbowsniffer/src/routes/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  interface Film {
+    id: number;
+    title: string;
+    rating: number;
+  }
+
+  let films: Film[] = [
+    { id: 1, title: 'The Matrix', rating: 0 },
+    { id: 2, title: 'Inception', rating: 0 },
+    { id: 3, title: 'The Godfather', rating: 0 }
+  ];
+
+  function setRating(film: Film, rating: number) {
+    film.rating = rating;
+  }
+</script>
+
+<h1>rainbowsniffer - Film Ratings</h1>
+<ul>
+  {#each films as film}
+    <li>
+      <span>{film.title}</span>
+      {#each Array(5) as _, i}
+        <button on:click={() => setRating(film, i + 1)}>
+          {i < film.rating ? '★' : '☆'}
+        </button>
+      {/each}
+    </li>
+  {/each}
+</ul>

--- a/rainbowsniffer/svelte.config.js
+++ b/rainbowsniffer/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/kit/vite';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter()
+  }
+};
+
+export default config;

--- a/rainbowsniffer/tsconfig.json
+++ b/rainbowsniffer/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/rainbowsniffer/vite.config.ts
+++ b/rainbowsniffer/vite.config.ts
@@ -1,0 +1,6 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()]
+});


### PR DESCRIPTION
## Summary
- add rainbowsniffer, a minimal SvelteKit app for rating films
- document project location in repository README
- extend .gitignore to cover SvelteKit artifacts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sveltejs%2fadapter-auto)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a08cd08c832ea502ace4c4b572ef